### PR TITLE
Feature/import-page

### DIFF
--- a/src/components/CsvWordTable.jsx
+++ b/src/components/CsvWordTable.jsx
@@ -1,0 +1,133 @@
+import { AgGridReact } from "ag-grid-react";
+import "ag-grid-community/styles/ag-grid.css"; // Core CSS
+import "ag-grid-community/styles/ag-theme-balham.css"; // Theme
+import React, { useEffect, useMemo, useState } from "react";
+import Papa from "papaparse";
+import { Button } from "react-bootstrap";
+import { postData } from "utils/api";
+
+export default function CsvWordTable({ csvData }) {
+	const gridRef = React.useRef(null);
+	const [rowData, setRowData] = useState([]);
+	const user_id = 1;
+	const [selectedWords, setSelectedWords] = useState([]);
+
+	const convertCSV = async (csv) => {
+		const data = Papa.parse(csv, {
+			header: true,
+		});
+		setRowData(convertToWordArray(data.data));
+	};
+
+	const convertToWordArray = (data) => {
+		const wordArray = [];
+		data.forEach((row) => {
+			const word = {
+				word: row.word,
+				rootWord: row.stem,
+				contextSentence: row.usage,
+				sourceLanguage: row.lang,
+				translatedTo: "EN-GB",
+				book: {
+					title: row.title,
+					author: row.authors,
+					language: row.lang,
+					isbn: row.isbn,
+				},
+			};
+			wordArray.push(word);
+		});
+		console.log(wordArray);
+		return wordArray;
+	};
+
+	useMemo(() => {
+		convertCSV(csvData);
+	}, [csvData]);
+
+	const columnDefs = [
+		{
+			headerName: "📖",
+			field: "sourceLanguage",
+			width: 60,
+			filter: true,
+		},
+		{
+			headerName: "Word",
+			field: "word",
+			width: 130,
+			filter: true,
+			headerCheckboxSelection: true,
+			headerCheckboxSelectionFilteredOnly: true,
+		},
+		{ headerName: "Stem", field: "rootWord", width: 130 },
+		{ headerName: "Usage", field: "contextSentence", width: 300 },
+		{
+			headerName: "Book",
+			field: "book.title",
+			width: 200,
+			filter: true,
+		},
+		{
+			headerName: "Author",
+			field: "book.author",
+			width: 150,
+			filter: true,
+		},
+		{
+			headerName: "ISBN",
+			field: "book.isbn",
+			width: 150,
+			filter: true,
+		},
+	];
+
+	const onSelectionChanged = (event) => {
+		const selectedNodes = event.api.getSelectedNodes();
+		const selectedWordObjects = [];
+		selectedNodes.map((node) => {
+			selectedWordObjects.push(node.data);
+		});
+		setSelectedWords(selectedWordObjects);
+	};
+
+	const importWords = async () => {
+		const response = await postData(
+			`api/word/user/${user_id}/multiple`,
+			selectedWords
+		);
+		console.log(response);
+	};
+
+	return (
+		<>
+			<p>
+				Select and deselect words by clicking on them, or add filters to the
+				columns and then check the checkbox to select all the words that match
+				that filter. When you have chosen your words, click the button below to
+				import them.
+			</p>
+			{/* Click a book title to select all words from that book:
+			<div>
+				<Button onClick={selectRowsFromBook}>
+					Select all rows from book "De getemde man"
+				</Button>
+				<Button onClick={() => setSelectedBook(null)}>Reset</Button>
+			 </div> */}
+			<div className="ag-theme-balham" style={{ height: 600, width: "100%" }}>
+				<AgGridReact
+					ref={gridRef}
+					columnDefs={columnDefs}
+					rowData={rowData}
+					pagination={true}
+					rowSelection="multiple"
+					rowMultiSelectWithClick={true}
+					onSelectionChanged={onSelectionChanged} // Event listener when selected rows changes
+				/>
+			</div>
+			<Button className="mt-3" onClick={importWords}>
+				Import words
+			</Button>
+		</>
+	);
+}

--- a/src/components/UploadKindleDB.jsx
+++ b/src/components/UploadKindleDB.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Button, Col, Row, Form } from "react-bootstrap";
 import { toast } from "react-toastify";
 import { uploadFile } from "utils/api";
+import CsvWordTable from "./CsvWordTable";
 
 export default function UploadKindleDB() {
 	const [file, setFile] = useState(null);
@@ -62,7 +63,9 @@ export default function UploadKindleDB() {
 				{data && (
 					<Row className="justify-items-between">
 						<Col>
-							<h5>CSV formatted data:</h5>
+							<h4>Select words to import</h4>
+							<CsvWordTable csvData={data} />
+							<h5 className="mt-3">CSV formatted data:</h5>
 							<pre>{data}</pre> {/* Display CSV data */}
 						</Col>
 					</Row>

--- a/src/components/WordTable.jsx
+++ b/src/components/WordTable.jsx
@@ -12,7 +12,7 @@ import {
 	postData,
 	putData,
 } from "utils/api";
-import { flagFormatter } from "utils/formatter";
+import { bookFormatter, flagFormatter } from "utils/formatter";
 
 export default function WordTable() {
 	const gridRef = React.useRef(null);
@@ -194,13 +194,6 @@ export default function WordTable() {
 	const handleSearchChange = (event) => {
 		const searchText = event.target.value;
 		setQuickFilterText(searchText);
-	};
-
-	const bookFormatter = (params) => {
-		if (params.value) {
-			return `${params.value.title} (${params.value.author})`;
-		}
-		return "N/A";
 	};
 
 	// Row Data: The data to be displayed.

--- a/src/utils/formatter.js
+++ b/src/utils/formatter.js
@@ -1,7 +1,10 @@
 export const flagFormatter = (params) => {
 	if (params.value != null) {
 		// if null, don't return anything
-		if (params.value === "EN-GB") {
+		if (
+			params.value.toUpperCase() === "EN-GB" ||
+			params.value.toUpperCase() === "EN"
+		) {
 			// this doesn't return the right flag so it's hard coded
 			return "🇬🇧";
 		}
@@ -11,4 +14,11 @@ export const flagFormatter = (params) => {
 			.map((char) => 127397 + char.charCodeAt());
 		return String.fromCodePoint(...codePoints);
 	}
+};
+
+export const bookFormatter = (params) => {
+	if (params.value) {
+		return `${params.value.title} (${params.value.author})`;
+	}
+	return "N/A";
 };


### PR DESCRIPTION
Can now import from db file, and select which words to add. 

To do: 
- add limit to words to add, so server doesn't get overloaded and apis don't cost too much
- improve root word service in backend so that rootword sent from frontend is used
- allow easier selection by book or language, so user can easily choose words to add
- change "en" to "EN-GB" in backend when saving words